### PR TITLE
Fixed alway truthful evaluation of typeof

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,7 +125,7 @@ Branch.prototype.drawMetadata = function () {
         Angles.FULL * length / tree.leaves.length :
         0;
     for (const columnName of metadata) {
-      if (typeof this.data[columnName] !== undefined) {
+      if (typeof this.data[columnName] !== 'undefined') {
         this.canvas.fillStyle = this.data[columnName];
         this.canvas.fillRect(tx, ty, length, size + i * stepCorrection);
       }


### PR DESCRIPTION
The javascript typeof operator always returns a string, including checking for the typeof undefined.  As written,  `typeof this.data[columnName]` will always return a string (either "undefined" or "string") and will always evaluate to `true` when compared to the primitive value `undefined`.  I was trying to decide if it would be better to change it to `typeof this.data[columnName] === 'string'` as it more directly maps to a column title.  I can make that change if @richardgoater you think it is better.
