### PR TITLE
Fix to phylocanvas-plugin-export-svg issue 2

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -191,7 +191,6 @@ function drawMetadata(branch) {
       }
       i++;
     }
-    ctx.stroke();
     ctx.closePath();
   }
 }


### PR DESCRIPTION
Hi Guys,

I think this should fix the issue that I added to the `phylocanvas-plugin-export-svg` "Error exporting svg when using metadata plugin". 

Josh