### PR TITLE
Add tooltip to metadata blocks; fix header alignment when header angle >0 set

### DIFF
--- a/dev/index.js
+++ b/dev/index.js
@@ -20,7 +20,7 @@ function getRandomLabel(length = 1 + Math.random() * 16) {
   return text;
 }
 
-const numberOfColumns = 4;
+const numberOfColumns = 10;
 
 const tree = PhyloCanvas.createTree('phylocanvas', {
   padding: 0,
@@ -28,14 +28,37 @@ const tree = PhyloCanvas.createTree('phylocanvas', {
     // show: true,
     // blockLength: 32,
     // blockSize: 32,
-    // padding: 16,
+    padding: 5,
     // // showHeaders: false,
     // // showLabels: false,
     // underlineHeaders: 'true',
-    // headerAngle: 0,
+    headerAngle: 0,
     // // font: '16px Sans-serif',
+    // tooltipFunc: (block) => {
+    //   const { columnName, data, leaf } = block;
+    //   return `
+    //   <table>
+    //     <thead>
+    //       <tr>
+    //         <th>Key</th>
+    //         <th>Val</th>
+    //       </tr>
+    //     </thead>
+    //     <tbody>
+    //       <tr>
+    //         <td><b>Sample</b></td>
+    //         <td>${leaf}</td>
+    //       </tr>
+    //       <tr>
+    //         <td><b>${columnName}</b></td>
+    //         <td>${data.label}</td>
+    //       </tr>
+    //     </tbody>
+    //   </table>
+    //   `;
+    // },
   },
-  baseNodeSize: 50,
+  baseNodeSize: 0,
 });
 
 // create buttons
@@ -50,14 +73,40 @@ for (const treeType of Object.keys(phyloComponents.treeTypes)) {
 const scaleRange = document.createElement('input');
 scaleRange.type = 'range';
 scaleRange.min = 1;
-scaleRange.max = 100;
+scaleRange.max = 200;
+scaleRange.value = 32;
 scaleRange.step = 1;
 scaleRange.addEventListener('change', () => {
   const value = Number(scaleRange.value);
   tree.metadata.blockLength = value;
-  tree.setNodeSize(value);
+  // tree.setNodeSize(value);
+  tree.draw();
 });
 buttonForm.appendChild(scaleRange);
+
+
+const headerAngleRotation = document.createElement('input');
+headerAngleRotation.type = 'range';
+headerAngleRotation.min = 0;
+headerAngleRotation.max = 90;
+headerAngleRotation.step = 1;
+headerAngleRotation.value = 0;
+headerAngleRotation.addEventListener('change', () => {
+  const value = Number(headerAngleRotation.value);
+  tree.metadata.headerAngle = value;
+  tree.draw();
+});
+buttonForm.appendChild(headerAngleRotation);
+
+
+const chkShowLabels = document.createElement('input');
+chkShowLabels.type = 'checkbox';
+chkShowLabels.checked = true;
+chkShowLabels.addEventListener('change', () => {
+  tree.metadata.showLabels = !tree.metadata.showLabels;
+  tree.draw();
+})
+buttonForm.appendChild(chkShowLabels)
 
 tree.on('error', event => { throw event.error; });
 


### PR DESCRIPTION
This pull request adds a tooltip for the metadata blocks using the existing PhyloCanvas tooltip and fixes the alignment of metadata headers when a header angle greater than 0 degrees is set. 

Here's how it looks:

![image](https://user-images.githubusercontent.com/4203424/42896399-6c4f96fc-8a82-11e8-9649-c561fb9b5f3a.png)

Users can also specify a custom function for setting the inner HTML of the tooltip. 
